### PR TITLE
Fix small dot rendering

### DIFF
--- a/sources/AimingDot.py
+++ b/sources/AimingDot.py
@@ -75,9 +75,25 @@ class App:
         self.dot_window.wm_attributes("-topmost", True)
         self.dot_window.wm_attributes("-transparentcolor", "white")
 
-        canvas = tk.Canvas(self.dot_window, width=size, height=size, bg="white", bd=0, highlightthickness=0)
+        # Using a 1 pixel padding prevents small dots from being clipped or
+        # appearing squared due to window borders.
+        canvas = tk.Canvas(
+            self.dot_window,
+            width=size + 2,
+            height=size + 2,
+            bg="white",
+            bd=0,
+            highlightthickness=0,
+        )
         canvas.pack()
-        canvas.create_oval(0, 0, size, size, fill=self.dot_color.get(), outline="")
+        canvas.create_oval(
+            1,
+            1,
+            size + 1,
+            size + 1,
+            fill=self.dot_color.get(),
+            outline="",
+        )
 
     def toggle_mouse_listener(self):
         if self.mouse_listener and self.mouse_listener.running:


### PR DESCRIPTION
## Summary
- adjust canvas size and oval bounds to keep dots round

## Testing
- `python3 -m py_compile sources/AimingDot.py`

------
https://chatgpt.com/codex/tasks/task_e_685586e94db483228ee2c6200c186186